### PR TITLE
Allow for protocol relative remote urls 

### DIFF
--- a/system/expressionengine/third_party/minimee/pi.minimee.php
+++ b/system/expressionengine/third_party/minimee/pi.minimee.php
@@ -1003,7 +1003,7 @@ class Minimee {
 			);
 
 			// from old _isURL() file from Carabiner Asset Management Library
-			if (preg_match('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', $this->filesdata[$key]['name']) > 0)
+			if (preg_match('@((https?:)?//([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', $this->filesdata[$key]['name']) > 0)
 			{
 				$this->filesdata[$key]['type'] = 'remote';
 			}


### PR DESCRIPTION
Currently you can't have a script/css remote href that starts with a `//`, while it should be totally valid as a protocol relative url.

http://paulirish.com/2010/the-protocol-relative-url/
