### PR TITLE
Fix Original Size Computation

### DIFF
--- a/system/expressionengine/third_party/minimee/classes/Minimee_lib.php
+++ b/system/expressionengine/third_party/minimee/classes/Minimee_lib.php
@@ -804,8 +804,6 @@ class Minimee_lib {
 	 */
 	protected function _minify($type, $contents, $filename, $rel = FALSE)
 	{
-		$before = strlen($contents);
-
 		// used in case we need to return orig
 		$contents_orig = $contents;
 	
@@ -927,6 +925,7 @@ class Minimee_lib {
 		endswitch;
 
 		// calculate weight loss
+		$before = strlen($contents_orig);
 		$after = strlen($contents);
 		$change = round((($before - $after) / $before) * 100, 2);
 


### PR DESCRIPTION
This commit makes the original size computation happen with the size after it is returned from outside modules.

I've been working with the Minimee+LESS plugin.  Compiled LESS happens to be larger than the uncompiled version, then minimee minifies the compiled LESS, but that is still larger than the uncompiled so it rejects the minified and returns the unminified (which is larger than the minified complied less).  Hopefully that all made since, what I have done is made the original size computation happen after the hooks are called.
