### PR TITLE
Version3 - Check if Minify library already exists before requiring/registering it

### DIFF
--- a/system/user/addons/minimee/classes/Minimee_helper.php
+++ b/system/user/addons/minimee/classes/Minimee_helper.php
@@ -141,8 +141,11 @@ class Minimee_helper {
 			@ini_set('memory_limit', '256M');
 
 			// Latest changes to Minify adopt a "loader" over sprinkled require's
-			require_once(PATH_THIRD . 'minimee/libraries/Minify/Loader.php');
-			Minify_Loader::register();
+            if ( ! class_exists('Minify_Loader')) {
+                require_once(PATH_THIRD . 'minimee/libraries/Minify/Loader.php');
+                Minify_Loader::register();
+            }
+
 
 			// don't do this again
 			get_instance()->session->cache['loader'] = TRUE;

--- a/system/user/addons/minimee/classes/Minimee_helper.php
+++ b/system/user/addons/minimee/classes/Minimee_helper.php
@@ -141,10 +141,10 @@ class Minimee_helper {
 			@ini_set('memory_limit', '256M');
 
 			// Latest changes to Minify adopt a "loader" over sprinkled require's
-            if ( ! class_exists('Minify_Loader')) {
-                require_once(PATH_THIRD . 'minimee/libraries/Minify/Loader.php');
-                Minify_Loader::register();
-            }
+			if ( ! class_exists('Minify_Loader')) {
+				require_once(PATH_THIRD . 'minimee/libraries/Minify/Loader.php');
+				Minify_Loader::register();
+			}
 
 
 			// don't do this again


### PR DESCRIPTION
I already had the Minify library and register was already called, so I changed it to check to see if the class exists before requiring and registering it.